### PR TITLE
refactor: replace np.pow with ** for numpy 1.19 & py3.6 support

### DIFF
--- a/ceco/cec/bent_cigar.py
+++ b/ceco/cec/bent_cigar.py
@@ -50,5 +50,5 @@ class Bent_cigar(Benchmark):
         sum_term = np.sum(shifted_rotated_vector[1:] ** 2)
 
         total_sum = shifted_rotated_vector[0] ** 2 + \
-            np.pow(10, 6) * sum_term + self.f_bias
+            (10 ** 6) * sum_term + self.f_bias
         return total_sum

--- a/ceco/cec/discus.py
+++ b/ceco/cec/discus.py
@@ -51,7 +51,7 @@ class Discus(Benchmark):
 
         sum_term = np.sum(shifted_rotated_vector[1:] ** 2)
 
-        total_sum = np.power(
-            10, 6) * shifted_rotated_vector[0] ** 2 + sum_term + self.f_bias
+        total_sum = (10 ** 6) * \
+            shifted_rotated_vector[0] ** 2 + sum_term + self.f_bias
 
         return total_sum

--- a/ceco/coco/bent_cigar.py
+++ b/ceco/coco/bent_cigar.py
@@ -64,7 +64,7 @@ class Bent_cigar(Benchmark):
 
         sum_term = np.sum(x[1:] ** 2)
 
-        total_sum = x[0] ** 2 + np.pow(10, 6) * sum_term
+        total_sum = x[0] ** 2 + (10 ** 6) * sum_term
 
         return total_sum
 

--- a/ceco/coco/discus.py
+++ b/ceco/coco/discus.py
@@ -64,7 +64,7 @@ class Discus(Benchmark):
 
         sum_term = np.sum(x[1:] ** 2)
 
-        total_sum = np.power(10, 6) * x[0] ** 2 + sum_term
+        total_sum = (10 ** 6) * x[0] ** 2 + sum_term
 
         return total_sum
 

--- a/ceco/coco/schaffer_f7.py
+++ b/ceco/coco/schaffer_f7.py
@@ -77,7 +77,7 @@ class Schaffer_f7(Benchmark):
             raise ValueError(
                 "all element in Input vector must be non-negative after transformation")
         sqrt_x_i = np.sqrt(x_i)
-        x_i_pow = np.power(x_i, 0.2)
+        x_i_pow = x_i ** 0.2
         sin_term = np.sin(50 * x_i_pow)
         inner_term = sqrt_x_i + sqrt_x_i * np.square(sin_term)
         total_sum = np.sum(inner_term)
@@ -105,7 +105,7 @@ class Schaffer_f7(Benchmark):
             raise ValueError(
                 "all element in Input vector must be non-negative after transformation")
         sqrt_s = np.sqrt(s)
-        s_pow = np.power(s, 0.2)
+        s_pow = s ** 0.2
         sin_term = np.sin(50 * s_pow)
         inner_term = sqrt_s + sqrt_s * np.square(sin_term)
         total_sum = np.sum(inner_term)

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(
     extras_require={
         "dev": ["pytest>=7.0", "twine>=4.0.2"],
     },
-    python_requires=">=3.7"
+    python_requires=">=3.6",
+    install_requires=['numpy>=1.19.0']
 )

--- a/test/coco/test_bent_cigar.py
+++ b/test/coco/test_bent_cigar.py
@@ -54,7 +54,7 @@ class Test_bent_cigar(unittest.TestCase):
         z = np.matmul(test_func.R, z)
         sum_term = np.sum(z[1:] ** 2)
         expected_result = z[0] ** 2 + \
-            np.pow(10, 6) * sum_term + test_func.f_opt
+            (10 ** 6) * sum_term + test_func.f_opt
         self.assertAlmostEqual(result, expected_result, places=6)
 
     def test_evaluate_with_negative_values(self):
@@ -73,7 +73,7 @@ class Test_bent_cigar(unittest.TestCase):
         z = np.matmul(test_func.R, z)
         sum_term = np.sum(z[1:] ** 2)
         expected_result = z[0] ** 2 + \
-            np.pow(10, 6) * sum_term + test_func.f_opt
+            (10 ** 6) * sum_term + test_func.f_opt
         self.assertAlmostEqual(result, expected_result, places=6)
 
     def test_evaluate_with_dimension_1(self):
@@ -92,7 +92,7 @@ class Test_bent_cigar(unittest.TestCase):
         z = np.matmul(test_func.R, z)
         sum_term = np.sum(z[1:] ** 2)
         expected_result = z[0] ** 2 + \
-            np.pow(10, 6) * sum_term + test_func.f_opt
+            (10 ** 6) * sum_term + test_func.f_opt
         self.assertAlmostEqual(result, expected_result, places=6)
 
     def test_evaluate_with_empty_input_vector(self):

--- a/test/coco/test_schaffer_f7.py
+++ b/test/coco/test_schaffer_f7.py
@@ -22,7 +22,6 @@ class Test_schaffer_f7(unittest.TestCase):
         self.assertAlmostEqual(test_func.f_opt, expected_f_opt, places=6)
 
         # Check the specific values of x_opt for reproducibility
-        print(test_func.x_opt)
         expected_x_opt = np.array(
             [1.87270059, 4.75357153, 3.65996971, 2.99329242, 0.7800932])
         self.assertTrue(np.allclose(test_func.x_opt,


### PR DESCRIPTION
- Replace all uses of np.pow with the ** operator
- Ensure compatibility with NumPy >=1.19 and Python >=3.6